### PR TITLE
feat: Add Ollama Docker Compose service and configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,17 @@ POSTGRES_PORT=5432
 # ---------------------------------------------------------------------------
 MEDIA_STORAGE=local
 
+# ---------------------------------------------------------------------------
+# Contextual AI redaction stage (Ollama)
+# Set OLLAMA_ENABLED=true to enable the Gemma contextual redaction stage.
+# Requires the ollama Docker Compose service to be running and a model pulled:
+#   docker compose up ollama -d
+#   docker exec tractor-ollama ollama pull gemma4:4b
+# ---------------------------------------------------------------------------
+# OLLAMA_ENABLED=true
+# OLLAMA_HOST=http://ollama:11434
+# OLLAMA_MODEL=gemma4:4b
+
 # S3 (requires: pip install django-storages[s3])
 # AWS_STORAGE_BUCKET_NAME=
 # AWS_S3_REGION_NAME=us-east-1

--- a/.env.example
+++ b/.env.example
@@ -33,11 +33,11 @@ MEDIA_STORAGE=local
 # Set OLLAMA_ENABLED=true to enable the Gemma contextual redaction stage.
 # Requires the ollama Docker Compose service to be running and a model pulled:
 #   docker compose up ollama -d
-#   docker exec tractor-ollama ollama pull gemma4:4b
+#   docker exec tractor-ollama ollama pull gemma4:e4b
 # ---------------------------------------------------------------------------
 # OLLAMA_ENABLED=true
 # OLLAMA_HOST=http://ollama:11434
-# OLLAMA_MODEL=gemma4:4b
+# OLLAMA_MODEL=gemma4:e4b
 
 # S3 (requires: pip install django-storages[s3])
 # AWS_STORAGE_BUCKET_NAME=

--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -194,6 +194,10 @@ ACCOUNT_EMAIL_VERIFICATION = "none"
 DELETE_ORIGINAL_FILES = False
 DELETE_ORIGINAL_FILES_AFTER_DAYS = 30
 
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://ollama:11434")
+OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:4b")
+OLLAMA_ENABLED = os.environ.get("OLLAMA_ENABLED")
+
 Q_CLUSTER = {
     "name": "DjangORM",
     "workers": 4,

--- a/backend/settings/base.py
+++ b/backend/settings/base.py
@@ -195,7 +195,7 @@ DELETE_ORIGINAL_FILES = False
 DELETE_ORIGINAL_FILES_AFTER_DAYS = 30
 
 OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://ollama:11434")
-OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:4b")
+OLLAMA_MODEL = os.environ.get("OLLAMA_MODEL", "gemma4:e4b")
 OLLAMA_ENABLED = os.environ.get("OLLAMA_ENABLED")
 
 Q_CLUSTER = {

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -55,8 +55,26 @@ services:
       - postgres_data:/var/lib/postgresql/data
     env_file: .env
 
+  ollama:
+    image: ollama/ollama
+    container_name: tractor-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    # Uncomment for NVIDIA GPU passthrough in production
+    # (requires NVIDIA drivers + nvidia-docker2 on the host):
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+
 volumes:
   postgres_data:
   static_volume:
   media_volume:
   nlp_models_volume:
+  ollama_data:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -58,8 +58,6 @@ services:
   ollama:
     image: ollama/ollama
     container_name: tractor-ollama
-    ports:
-      - "11434:11434"
     volumes:
       - ollama_data:/root/.ollama
     # Uncomment for NVIDIA GPU passthrough in production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   db:
     restart: always
     image: postgres:15
-    container_name: tractor-postgres 
+    container_name: tractor-postgres
     env_file:
       - '.env'
     ports:
@@ -11,5 +11,23 @@ services:
     volumes:
       - ./postgres_data:/var/lib/postgresql/data/
 
+  ollama:
+    image: ollama/ollama
+    container_name: tractor-ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    # Uncomment for NVIDIA GPU passthrough in production
+    # (requires NVIDIA drivers + nvidia-docker2 on the host):
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
+
 volumes:
   postgres_data:
+  ollama_data:


### PR DESCRIPTION
## Summary

- Adds `ollama` service to `docker-compose.yml` with a persistent named volume and a commented-out NVIDIA GPU passthrough block for production deployments
- Adds `OLLAMA_HOST`, `OLLAMA_MODEL`, and `OLLAMA_ENABLED` to `backend/settings/base.py`
- Documents all three variables in `.env.example` with setup instructions

## Test plan

- [x] `docker compose up ollama -d` starts the container successfully
- [x] `docker exec tractor-ollama ollama pull gemma4:e4b` pulls the model and persists to the named volume
- [x] Container restart does not lose the pulled model (`ollama_data` volume survives)
- [x] Django settings resolve correct defaults when env vars are absent

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)