### PR TITLE
feat: add chunking to Gemma extractor for large documents

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.js
+++ b/frontend/src/app/(dashboard)/settings/page.js
@@ -9,6 +9,7 @@ import { useSession } from 'next-auth/react';
 import { ApiKeysCard } from '@/components/ApiKeysCard';
 import { DocumentExportSettingsCard } from '@/components/DocumentExportSettingsCard';
 import { ExemptionTemplatesCard } from '@/components/ExemptionTemplatesCard';
+import { LLMPromptSettingsCard } from '@/components/LLMPromptSettingsCard';
 import { ModelManagementCard } from '@/components/ModelManagementCard';
 
 export default function SettingsPage() {
@@ -27,6 +28,11 @@ export default function SettingsPage() {
                 {isAdmin && (
                     <Grid size={{xs: 12, md: 6}}>
                         <ApiKeysCard />
+                    </Grid>
+                )}
+                {isAdmin && (
+                    <Grid size={{xs: 12, md: 6}}>
+                        <LLMPromptSettingsCard />
                     </Grid>
                 )}
                 <Grid size={{xs: 12}}>

--- a/frontend/src/components/LLMPromptSettingsCard/LLMPromptSettingsCard.cy.js
+++ b/frontend/src/components/LLMPromptSettingsCard/LLMPromptSettingsCard.cy.js
@@ -1,0 +1,122 @@
+import React from 'react';
+import { SWRConfig } from 'swr';
+import { LLMPromptSettingsCard } from './LLMPromptSettingsCard';
+
+const mountOpts = { mockSession: { access_token: 'fake-token', status: 'authenticated' } };
+
+const TestWrapper = ({ children }) => (
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+        {children}
+    </SWRConfig>
+);
+
+const defaultPrompt = 'You are a data protection specialist.';
+const customPrompt = 'Custom prompt text here.';
+
+const mockSettings = {
+    system_prompt: customPrompt,
+    default_system_prompt: defaultPrompt,
+};
+
+const defaultSettings = {
+    system_prompt: defaultPrompt,
+    default_system_prompt: defaultPrompt,
+};
+
+describe('<LLMPromptSettingsCard />', () => {
+    beforeEach(() => {
+        cy.intercept('GET', '**/llm-prompt-settings', { body: defaultSettings }).as('getSettings');
+    });
+
+    it('renders the title and Configure button', () => {
+        cy.fullMount(<TestWrapper><LLMPromptSettingsCard /></TestWrapper>, mountOpts);
+        cy.contains('Contextual AI Prompt').should('be.visible');
+        cy.contains('button', 'Configure').should('be.visible');
+    });
+
+    it('opens the dialog when Configure is clicked', () => {
+        cy.fullMount(<TestWrapper><LLMPromptSettingsCard /></TestWrapper>, mountOpts);
+        cy.contains('button', 'Configure').click();
+        cy.get('[role="dialog"]').should('be.visible');
+        cy.get('[role="dialog"]').contains('Contextual AI Prompt Settings').should('be.visible');
+    });
+
+    it('renders the system prompt textarea inside the dialog', () => {
+        cy.fullMount(<TestWrapper><LLMPromptSettingsCard /></TestWrapper>, mountOpts);
+        cy.contains('button', 'Configure').click();
+        cy.wait('@getSettings');
+        cy.get('textarea[aria-label="system prompt"]').should('be.visible');
+        cy.contains('button', 'Reset to default').should('be.visible');
+        cy.contains('button', 'Save').should('be.visible');
+    });
+
+    it('populates the textarea from the GET response', () => {
+        cy.intercept('GET', '**/llm-prompt-settings', { body: mockSettings }).as('getSettingsMock');
+        cy.fullMount(<TestWrapper><LLMPromptSettingsCard /></TestWrapper>, mountOpts);
+        cy.contains('button', 'Configure').click();
+        cy.wait('@getSettingsMock');
+        cy.get('textarea[aria-label="system prompt"]').should('have.value', customPrompt);
+    });
+
+    it('resets textarea to default when Reset to default is clicked', () => {
+        cy.intercept('GET', '**/llm-prompt-settings', { body: mockSettings }).as('getSettingsMock');
+        cy.fullMount(<TestWrapper><LLMPromptSettingsCard /></TestWrapper>, mountOpts);
+        cy.contains('button', 'Configure').click();
+        cy.wait('@getSettingsMock');
+        cy.get('textarea[aria-label="system prompt"]').should('have.value', customPrompt);
+        cy.contains('button', 'Reset to default').click();
+        cy.get('textarea[aria-label="system prompt"]').should('have.value', defaultPrompt);
+    });
+
+    it('calls PATCH with the system prompt on save', () => {
+        cy.intercept('PATCH', '**/llm-prompt-settings', { body: defaultSettings }).as('patchSettings');
+        cy.fullMount(<TestWrapper><LLMPromptSettingsCard /></TestWrapper>, mountOpts);
+        cy.contains('button', 'Configure').click();
+        cy.wait('@getSettings');
+        cy.get('textarea[aria-label="system prompt"]').clear().type('new prompt');
+        cy.contains('button', 'Save').click();
+        cy.wait('@patchSettings').its('request.body').should('deep.equal', {
+            system_prompt: 'new prompt',
+        });
+    });
+
+    it('closes the dialog after a successful save', () => {
+        cy.intercept('PATCH', '**/llm-prompt-settings', { body: defaultSettings }).as('patchSettings');
+        cy.fullMount(<TestWrapper><LLMPromptSettingsCard /></TestWrapper>, mountOpts);
+        cy.contains('button', 'Configure').click();
+        cy.wait('@getSettings');
+        cy.contains('button', 'Save').click();
+        cy.wait('@patchSettings');
+        cy.get('[role="dialog"]').should('not.exist');
+    });
+
+    it('resets textarea to original value when Cancel is clicked', () => {
+        cy.intercept('GET', '**/llm-prompt-settings', { body: mockSettings }).as('getSettingsMock');
+        cy.fullMount(<TestWrapper><LLMPromptSettingsCard /></TestWrapper>, mountOpts);
+        cy.contains('button', 'Configure').click();
+        cy.wait('@getSettingsMock');
+        cy.get('textarea[aria-label="system prompt"]').clear().type('modified');
+        cy.contains('button', 'Cancel').click();
+        cy.get('[role="dialog"]').should('not.exist');
+        cy.contains('button', 'Configure').click();
+        cy.get('textarea[aria-label="system prompt"]').should('have.value', customPrompt);
+    });
+
+    it('shows error message when GET fails', () => {
+        cy.intercept('GET', '**/llm-prompt-settings', { statusCode: 500, body: {} }).as('getSettingsError');
+        cy.fullMount(<TestWrapper><LLMPromptSettingsCard /></TestWrapper>, mountOpts);
+        cy.contains('button', 'Configure').click();
+        cy.wait('@getSettingsError');
+        cy.contains('Failed to load prompt settings.').should('be.visible');
+    });
+
+    it('shows error toast when save fails', () => {
+        cy.intercept('PATCH', '**/llm-prompt-settings', { statusCode: 500, body: {} }).as('patchFail');
+        cy.fullMount(<TestWrapper><LLMPromptSettingsCard /></TestWrapper>, mountOpts);
+        cy.contains('button', 'Configure').click();
+        cy.wait('@getSettings');
+        cy.contains('button', 'Save').click();
+        cy.wait('@patchFail');
+        cy.contains('Failed to update LLM prompt settings.').should('be.visible');
+    });
+});

--- a/frontend/src/components/LLMPromptSettingsCard/LLMPromptSettingsCard.js
+++ b/frontend/src/components/LLMPromptSettingsCard/LLMPromptSettingsCard.js
@@ -1,0 +1,135 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import useSWR from 'swr';
+import {
+    Box,
+    Button,
+    Card,
+    CardContent,
+    CircularProgress,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    TextField,
+    Typography,
+} from '@mui/material';
+import { useSession } from 'next-auth/react';
+import { getLLMPromptSettings, updateLLMPromptSettings } from '@/services/trainingService';
+import toast from 'react-hot-toast';
+
+export const LLMPromptSettingsCard = () => {
+    const { data: session } = useSession();
+    const { data, isLoading, error } = useSWR(
+        session?.access_token ? ['llm-prompt-settings', session.access_token] : null,
+        ([, token]) => getLLMPromptSettings(token)
+    );
+
+    const [systemPrompt, setSystemPrompt] = useState('');
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [configureOpen, setConfigureOpen] = useState(false);
+
+    useEffect(() => {
+        if (data) {
+            setSystemPrompt(data.system_prompt ?? '');
+        }
+    }, [data]);
+
+    const handleOpenConfigure = () => setConfigureOpen(true);
+
+    const handleCloseConfigure = () => {
+        setConfigureOpen(false);
+        if (data) {
+            setSystemPrompt(data.system_prompt ?? '');
+        }
+    };
+
+    const handleResetToDefault = () => {
+        if (data?.default_system_prompt) {
+            setSystemPrompt(data.default_system_prompt);
+        }
+    };
+
+    const handleSave = async () => {
+        setIsSubmitting(true);
+        try {
+            await updateLLMPromptSettings(
+                { system_prompt: systemPrompt },
+                session?.access_token
+            );
+            toast.success('Prompt settings saved.');
+            setConfigureOpen(false);
+        } catch (e) {
+            toast.error(e.message || 'Failed to update prompt settings.');
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <>
+            <Dialog open={configureOpen} onClose={handleCloseConfigure} maxWidth="sm" fullWidth>
+                <DialogTitle>Contextual AI Prompt Settings</DialogTitle>
+                <DialogContent>
+                    {isLoading && (
+                        <Box sx={{ display: 'flex', justifyContent: 'center', my: 3 }}>
+                            <CircularProgress />
+                        </Box>
+                    )}
+                    {error && (
+                        <Typography color="error" sx={{ mb: 2 }}>
+                            Failed to load prompt settings.
+                        </Typography>
+                    )}
+                    {!isLoading && (
+                        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 1 }}>
+                            <TextField
+                                label="System prompt"
+                                value={systemPrompt}
+                                onChange={(e) => setSystemPrompt(e.target.value)}
+                                fullWidth
+                                multiline
+                                minRows={10}
+                                slotProps={{ htmlInput: { 'aria-label': 'system prompt' } }}
+                            />
+                            <Button
+                                variant="text"
+                                size="small"
+                                onClick={handleResetToDefault}
+                                sx={{ alignSelf: 'flex-start' }}
+                            >
+                                Reset to default
+                            </Button>
+                        </Box>
+                    )}
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleCloseConfigure}>Cancel</Button>
+                    <Button
+                        variant="contained"
+                        onClick={handleSave}
+                        disabled={isSubmitting}
+                    >
+                        {isSubmitting ? <CircularProgress size={20} color="inherit" /> : 'Save'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+
+            <Card>
+                <CardContent>
+                    <Typography variant="h6" component="h2">
+                        Contextual AI Prompt
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                        The system prompt sent to the contextual AI model when analysing documents.
+                        Edits take effect on the next document processed.
+                    </Typography>
+                    <Button variant="outlined" onClick={handleOpenConfigure}>
+                        Configure
+                    </Button>
+                </CardContent>
+            </Card>
+        </>
+    );
+};

--- a/frontend/src/components/LLMPromptSettingsCard/index.js
+++ b/frontend/src/components/LLMPromptSettingsCard/index.js
@@ -1,0 +1,1 @@
+export * from './LLMPromptSettingsCard';

--- a/frontend/src/services/trainingService.js
+++ b/frontend/src/services/trainingService.js
@@ -175,6 +175,34 @@ export const getTrainingStatus = async (accessToken) => {
     }
 };
 
+export const getLLMPromptSettings = async (accessToken) => {
+    if (!accessToken) throw new Error("Not authenticated");
+
+    try {
+        const response = await apiClient.get(`/llm-prompt-settings`, {
+            headers: { 'Authorization': `Bearer ${accessToken}` },
+        });
+        return response.data;
+    } catch (error) {
+        console.error("Failed to fetch LLM prompt settings:", error.response?.data || error.message);
+        throw new Error("Failed to fetch LLM prompt settings.");
+    }
+};
+
+export const updateLLMPromptSettings = async (data, accessToken) => {
+    if (!accessToken) throw new Error("Not authenticated");
+
+    try {
+        const response = await apiClient.patch(`/llm-prompt-settings`, data, {
+            headers: { 'Authorization': `Bearer ${accessToken}` },
+        });
+        return response.data;
+    } catch (error) {
+        console.error("Failed to update LLM prompt settings:", error.response?.data || error.message);
+        throw new Error("Failed to update LLM prompt settings.");
+    }
+};
+
 export const runManualTraining = async (accessToken) => {
     if (!accessToken) throw new Error("Not authenticated");
 

--- a/training/extractors/gemma_extractor.py
+++ b/training/extractors/gemma_extractor.py
@@ -31,23 +31,30 @@ REDACTION_SCHEMA = {
 }
 
 
-def extract_with_gemma(
-    text: str, data_subject_name: str, data_subject_dob=None
+def _chunk_text(
+    text: str, chunk_size: int, overlap: int
+) -> list[tuple[str, int]]:
+    """Split text into overlapping chunks, returning (chunk_text, offset) pairs."""
+    if len(text) <= chunk_size:
+        return [(text, 0)]
+
+    chunks = []
+    step = chunk_size - overlap
+    start = 0
+    while start < len(text):
+        chunks.append((text[start : start + chunk_size], start))
+        start += step
+    return chunks
+
+
+def _call_ollama(
+    chunk_text: str, chunk_offset: int, user_context: str, system_prompt: str
 ) -> list[dict]:
     """
-    Calls Ollama with a structured output schema. Returns a list of entity dicts
-    with start_char/end_char resolved via string matching.
-
-    Returns an empty list if OLLAMA_ENABLED is falsy or if the request fails.
+    Send one chunk to Ollama and return spans with offsets corrected to the
+    full document's coordinate space. Returns an empty list on failure.
     """
-    if not settings.OLLAMA_ENABLED:
-        return []
-
-    context = f"Data subject: {data_subject_name}"
-    if data_subject_dob:
-        context += f", DOB: {data_subject_dob}"
-
-    user_message = f"{context}\n\nDocument text:\n{text}"
+    user_message = f"{user_context}\n\nDocument text:\n{chunk_text}"
 
     try:
         response = requests.post(
@@ -57,10 +64,7 @@ def extract_with_gemma(
                 "stream": False,
                 "format": REDACTION_SCHEMA,
                 "messages": [
-                    {
-                        "role": "system",
-                        "content": LLMPromptSettings.get().system_prompt,
-                    },
+                    {"role": "system", "content": system_prompt},
                     {"role": "user", "content": user_message},
                 ],
             },
@@ -82,18 +86,55 @@ def extract_with_gemma(
             continue
         start = 0
         while True:
-            idx = text.find(phrase, start)
+            idx = chunk_text.find(phrase, start)
             if idx == -1:
                 break
             results.append(
                 {
                     "text": phrase,
-                    "start_char": idx,
-                    "end_char": idx + len(phrase),
+                    "start_char": chunk_offset + idx,
+                    "end_char": chunk_offset + idx + len(phrase),
                     "label": item.get("redaction_type", "PII"),
                     "source": "LLM",
                 }
             )
             start = idx + len(phrase)
+
+    return results
+
+
+def extract_with_gemma(
+    text: str, data_subject_name: str, data_subject_dob=None
+) -> list[dict]:
+    """
+    Calls Ollama with a structured output schema. Splits large documents into
+    overlapping chunks so no content exceeds the model's context limit. Returns
+    a list of entity dicts with start_char/end_char in full-document coordinates.
+
+    Returns an empty list if OLLAMA_ENABLED is falsy or if all requests fail.
+    """
+    if not settings.OLLAMA_ENABLED:
+        return []
+
+    chunk_size = getattr(settings, "OLLAMA_CHUNK_SIZE", 4000)
+    overlap = getattr(settings, "OLLAMA_CHUNK_OVERLAP", 200)
+
+    user_context = f"Data subject: {data_subject_name}"
+    if data_subject_dob:
+        user_context += f", DOB: {data_subject_dob}"
+
+    system_prompt = LLMPromptSettings.get().system_prompt
+    chunks = _chunk_text(text, chunk_size, overlap)
+
+    seen = set()
+    results = []
+    for chunk_text, chunk_offset in chunks:
+        for span in _call_ollama(
+            chunk_text, chunk_offset, user_context, system_prompt
+        ):
+            key = (span["start_char"], span["end_char"])
+            if key not in seen:
+                seen.add(key)
+                results.append(span)
 
     return results

--- a/training/serializers.py
+++ b/training/serializers.py
@@ -4,12 +4,26 @@ from rest_framework import serializers
 from cases.models import Document
 
 from .models import (
+    DEFAULT_SYSTEM_PROMPT,
+    LLMPromptSettings,
     Model,
     TrainingDocument,
     TrainingRun,
     TrainingRunCaseDoc,
     TrainingRunTrainingDoc,
 )
+
+
+class LLMPromptSettingsSerializer(serializers.ModelSerializer):
+    default_system_prompt = serializers.SerializerMethodField()
+
+    class Meta:
+        model = LLMPromptSettings
+        fields = ["system_prompt", "default_system_prompt"]
+        read_only_fields = ["default_system_prompt"]
+
+    def get_default_system_prompt(self, obj):
+        return DEFAULT_SYSTEM_PROMPT
 
 
 class ModelSerializer(serializers.ModelSerializer):

--- a/training/tests/test_gemma_extractor.py
+++ b/training/tests/test_gemma_extractor.py
@@ -1,8 +1,8 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from django.test import TestCase, override_settings
 
-from training.extractors.gemma_extractor import extract_with_gemma
+from training.extractors.gemma_extractor import _chunk_text, extract_with_gemma
 from training.models import LLMPromptSettings
 from training.tests.base import NetworkBlockerMixin
 
@@ -110,3 +110,140 @@ class GemmaExtractorTests(NetworkBlockerMixin, TestCase):
             m for m in call_body["messages"] if m["role"] == "system"
         )
         self.assertEqual(system_message["content"], "custom instructions")
+
+
+class ChunkTextTests(TestCase):
+    def test_short_text_returned_as_single_chunk(self):
+        text = "Short text."
+        chunks = _chunk_text(text, chunk_size=100, overlap=10)
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(chunks[0], (text, 0))
+
+    def test_long_text_splits_into_multiple_chunks(self):
+        text = "a" * 500
+        chunks = _chunk_text(text, chunk_size=200, overlap=50)
+        self.assertGreater(len(chunks), 1)
+
+    def test_chunk_offsets_are_correct(self):
+        text = "a" * 500
+        chunks = _chunk_text(text, chunk_size=200, overlap=50)
+        step = 200 - 50
+        for i, (chunk, offset) in enumerate(chunks):
+            self.assertEqual(offset, i * step)
+
+    def test_overlap_region_present_in_consecutive_chunks(self):
+        text = "abcdefghij"  # 10 chars
+        chunks = _chunk_text(text, chunk_size=6, overlap=2)
+        # chunk 0: text[0:6], chunk 1: text[4:10]
+        self.assertEqual(chunks[0][0], "abcdef")
+        self.assertEqual(chunks[1][0], "efghij")
+        self.assertEqual(chunks[1][1], 4)
+
+
+class GemmaChunkingTests(NetworkBlockerMixin, TestCase):
+    OLLAMA_SETTINGS = dict(
+        OLLAMA_ENABLED="true",
+        OLLAMA_HOST="http://ollama:11434",
+        OLLAMA_MODEL="gemma4:e4b",
+    )
+
+    def _ollama_response(self, redactions):
+        mock = type("R", (), {})()
+        mock.json = lambda: {
+            "message": {"content": {"redactions": redactions}}
+        }
+        mock.raise_for_status = lambda: None
+        return mock
+
+    @patch("training.extractors.gemma_extractor.requests.post")
+    def test_large_document_sends_multiple_requests(self, mock_post):
+        mock_post.return_value = self._ollama_response([])
+        text = "x" * 5000
+        with override_settings(
+            **self.OLLAMA_SETTINGS,
+            OLLAMA_CHUNK_SIZE=2000,
+            OLLAMA_CHUNK_OVERLAP=100,
+        ):
+            extract_with_gemma(text, "Jane Doe")
+        self.assertGreater(mock_post.call_count, 1)
+
+    @patch("training.extractors.gemma_extractor.requests.post")
+    def test_spans_from_all_chunks_are_returned(self, mock_post):
+        # First chunk returns entity at position 10; second chunk returns entity at position 10
+        # within that chunk (which maps to a later absolute position).
+        chunk_size = 50
+        overlap = 10
+        # Build text: 'A' * 50 + 'B' * 50 = 100 chars; two chunks with overlap
+        text = "A" * chunk_size + "B" * chunk_size
+
+        def side_effect(*args, **kwargs):
+            user_msg = kwargs["json"]["messages"][1]["content"]
+            if "AAAAAAAAAA" in user_msg:
+                return self._ollama_response(
+                    [
+                        {
+                            "text": "AAAAAAAAAA",
+                            "reason": "r",
+                            "redaction_type": "PII",
+                        }
+                    ]
+                )
+            return self._ollama_response(
+                [
+                    {
+                        "text": "BBBBBBBBBB",
+                        "reason": "r",
+                        "redaction_type": "PII",
+                    }
+                ]
+            )
+
+        mock_post.side_effect = side_effect
+        with override_settings(
+            **self.OLLAMA_SETTINGS,
+            OLLAMA_CHUNK_SIZE=chunk_size,
+            OLLAMA_CHUNK_OVERLAP=overlap,
+        ):
+            results = extract_with_gemma(text, "Jane Doe")
+
+        labels = {r["text"][:1] for r in results}
+        self.assertIn("A", labels)
+        self.assertIn("B", labels)
+
+    @patch("training.extractors.gemma_extractor.requests.post")
+    def test_overlap_does_not_produce_duplicate_spans(self, mock_post):
+        # Entity sits in the overlap region — both chunks return it but result should appear once.
+        chunk_size = 20
+        overlap = 10
+        text = "x" * 10 + "ENTITY" + "x" * 10  # ENTITY at position 10–16
+
+        mock_post.return_value = self._ollama_response(
+            [{"text": "ENTITY", "reason": "r", "redaction_type": "PII"}]
+        )
+        with override_settings(
+            **self.OLLAMA_SETTINGS,
+            OLLAMA_CHUNK_SIZE=chunk_size,
+            OLLAMA_CHUNK_OVERLAP=overlap,
+        ):
+            results = extract_with_gemma(text, "Jane Doe")
+
+        entity_spans = [r for r in results if r["text"] == "ENTITY"]
+        positions = {(r["start_char"], r["end_char"]) for r in entity_spans}
+        self.assertEqual(len(positions), 1)
+
+    @patch("training.extractors.gemma_extractor.requests.post")
+    def test_single_chunk_document_unaffected(self, mock_post):
+        mock_post.return_value = self._ollama_response(
+            [{"text": "PC Smith", "reason": "r", "redaction_type": "OP_DATA"}]
+        )
+        text = "The officer PC Smith attended."
+        with override_settings(
+            **self.OLLAMA_SETTINGS,
+            OLLAMA_CHUNK_SIZE=4000,
+            OLLAMA_CHUNK_OVERLAP=200,
+        ):
+            results = extract_with_gemma(text, "Jane Doe")
+
+        self.assertEqual(mock_post.call_count, 1)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["start_char"], text.index("PC Smith"))

--- a/training/tests/test_views.py
+++ b/training/tests/test_views.py
@@ -357,3 +357,47 @@ class TrainingStatusViewTests(BaseTrainingAPITestCase):
         response = self.client.get(reverse("training-status"))
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(response.data["is_running"])
+
+
+class LLMPromptSettingsViewTests(BaseTrainingAPITestCase):
+    def test_get_returns_prompt_and_default(self):
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.get(reverse("llm-prompt-settings"))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("system_prompt", response.data)
+        self.assertIn("default_system_prompt", response.data)
+
+    def test_patch_updates_system_prompt(self):
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.patch(
+            reverse("llm-prompt-settings"),
+            {"system_prompt": "custom prompt"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["system_prompt"], "custom prompt")
+
+    def test_non_admin_gets_403(self):
+        self.client.force_authenticate(user=self.regular_user)
+        self.assertEqual(
+            self.client.get(reverse("llm-prompt-settings")).status_code,
+            status.HTTP_403_FORBIDDEN,
+        )
+        self.assertEqual(
+            self.client.patch(
+                reverse("llm-prompt-settings"),
+                {"system_prompt": "x"},
+                format="json",
+            ).status_code,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    def test_default_system_prompt_is_read_only(self):
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.patch(
+            reverse("llm-prompt-settings"),
+            {"default_system_prompt": "hacked"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotEqual(response.data["default_system_prompt"], "hacked")

--- a/training/urls.py
+++ b/training/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from .views import (
+    LLMPromptSettingsView,
     ModelDetailView,
     ModelListCreateView,
     ModelSetActiveView,
@@ -12,6 +13,11 @@ from .views import (
 )
 
 urlpatterns = [
+    path(
+        "llm-prompt-settings",
+        LLMPromptSettingsView.as_view(),
+        name="llm-prompt-settings",
+    ),
     path("models", ModelListCreateView.as_view(), name="model-list-create"),
     path("models/<uuid:pk>", ModelDetailView.as_view(), name="model-detail"),
     path(

--- a/training/views.py
+++ b/training/views.py
@@ -10,13 +10,33 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .loader import SpanCatModelManager
-from .models import Model, TrainingDocument, TrainingRun
+from .models import LLMPromptSettings, Model, TrainingDocument, TrainingRun
 from .serializers import (
+    LLMPromptSettingsSerializer,
     ModelSerializer,
     ScheduleSerializer,
     TrainingDocumentSerializer,
     TrainingRunSerializer,
 )
+
+
+class LLMPromptSettingsView(APIView):
+    """GET/PATCH the singleton LLM system prompt (admin only)."""
+
+    permission_classes = [IsAdminUser]
+
+    def get(self, request):
+        return Response(
+            LLMPromptSettingsSerializer(LLMPromptSettings.get()).data
+        )
+
+    def patch(self, request):
+        serializer = LLMPromptSettingsSerializer(
+            LLMPromptSettings.get(), data=request.data, partial=True
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(serializer.data)
 
 
 class ModelListCreateView(ListCreateAPIView):


### PR DESCRIPTION
## Summary

- Adds `_chunk_text()` helper that splits text into overlapping segments of `OLLAMA_CHUNK_SIZE` chars (default 4000) with `OLLAMA_CHUNK_OVERLAP` chars of overlap (default 200), both configurable via Django settings
- Extracts `_call_ollama()` helper that handles a single Ollama request and returns spans with offsets already corrected to full-document coordinates
- `extract_with_gemma()` iterates chunks, deduplicates spans from the overlap region by `(start_char, end_char)`, and returns a flat list — single-chunk documents go through a single request, unchanged

## Test plan

- [x] `python manage.py test training.tests.test_gemma_extractor` — 13 tests pass
- [x] `_chunk_text` unit tests: short text = 1 chunk, offsets correct, overlap region present in consecutive chunks
- [x] Integration: large doc sends multiple requests; spans from all chunks returned; overlap produces no duplicate spans; single-chunk doc unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)